### PR TITLE
feat: build manifests; CI check

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -10,6 +10,15 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  manifests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Generate
+        run: cargo run -- manifests
+      - name: Diff
+        run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
+
   build:
     runs-on: ubuntu-latest
 

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Generate
-        run: cargo run -- manifests
+        run: cargo run -- manifests > manifests/crd.yml
       - name: Diff
         run: test -z "$(git status --porcelain)" || (echo 'Changes detected after generating manifests'; git status; git --no-pager diff; false)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,6 +1542,7 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
+ "serde_yaml",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ tracing = "0.1"
 schemars = "0.8.11"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_yaml = "0.8.21"
 jsonpath_lib = "0.3.0"
 thiserror = "1"
 

--- a/manifests/crd.yml
+++ b/manifests/crd.yml
@@ -137,3 +137,4 @@ spec:
       storage: true
       subresources:
         status: {}
+

--- a/manifests/crd.yml
+++ b/manifests/crd.yml
@@ -1,0 +1,139 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resourcesyncs.sinker.influxdata.io
+spec:
+  group: sinker.influxdata.io
+  names:
+    categories: []
+    kind: ResourceSync
+    plural: resourcesyncs
+    shortNames: []
+    singular: resourcesync
+  scope: Namespaced
+  versions:
+    - additionalPrinterColumns: []
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          description: "Auto-generated derived type for ResourceSyncSpec via `CustomResource`"
+          properties:
+            spec:
+              properties:
+                mappings:
+                  items:
+                    properties:
+                      fromFieldPath:
+                        nullable: true
+                        type: string
+                      toFieldPath:
+                        type: string
+                    required:
+                      - toFieldPath
+                    type: object
+                  type: array
+                source:
+                  properties:
+                    cluster:
+                      nullable: true
+                      properties:
+                        kubeConfig:
+                          properties:
+                            secretRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        namespace:
+                          nullable: true
+                          type: string
+                      required:
+                        - kubeConfig
+                      type: object
+                    resourceRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                        - apiVersion
+                        - kind
+                        - name
+                      type: object
+                  required:
+                    - resourceRef
+                  type: object
+                target:
+                  properties:
+                    cluster:
+                      nullable: true
+                      properties:
+                        kubeConfig:
+                          properties:
+                            secretRef:
+                              properties:
+                                key:
+                                  type: string
+                                name:
+                                  type: string
+                              required:
+                                - key
+                                - name
+                              type: object
+                          required:
+                            - secretRef
+                          type: object
+                        namespace:
+                          nullable: true
+                          type: string
+                      required:
+                        - kubeConfig
+                      type: object
+                    resourceRef:
+                      properties:
+                        apiVersion:
+                          type: string
+                        kind:
+                          type: string
+                        name:
+                          type: string
+                      required:
+                        - apiVersion
+                        - kind
+                        - name
+                      type: object
+                  required:
+                    - resourceRef
+                  type: object
+              required:
+                - source
+                - target
+              type: object
+            status:
+              nullable: true
+              properties:
+                demo:
+                  type: string
+              required:
+                - demo
+              type: object
+          required:
+            - spec
+          title: ResourceSync
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,14 +25,11 @@ async fn main() -> anyhow::Result<()> {
         admin: kubert::AdminArgs,
 
         #[command(subcommand)]
-        command: Commands,
+        command: Option<Commands>,
     }
 
     #[derive(Clone, Subcommand)]
     enum Commands {
-        /// Run the controller
-        Run,
-
         /// Generates k8s manifests
         Manifests,
     }
@@ -46,13 +43,13 @@ async fn main() -> anyhow::Result<()> {
     } = Args::parse();
 
     match &command {
-        Commands::Manifests => {
+        Some(Commands::Manifests) => {
             println!(
                 "{}",
                 serde_yaml::to_string(&sinker::resources::ResourceSync::crd()).unwrap()
             );
         }
-        Commands::Run => {
+        None => {
             let rt = kubert::Runtime::builder()
                 .with_log(log_level, log_format)
                 .with_admin(admin)


### PR DESCRIPTION
this adds a subcommand to generate the CRD manifests:

```
$ cargo run -- --help
    Finished dev [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/sinker --help`
Command-line arguments used to configure an admin server

Usage: sinker [OPTIONS] <COMMAND>

Commands:
  manifests  Generates k8s manifests
  help       Print this message or the help of the given subcommand(s)

Options:
      --log-level <LOG_LEVEL>         The tracing filter used for logs [env: SINKER_LOG=] [default: sinker=info,warn]
      --log-format <LOG_FORMAT>       The logging format [default: plain]
      --cluster <CLUSTER>             The name of the kubeconfig cluster to use
      --context <CONTEXT>             The name of the kubeconfig context to use
      --user <USER>                   The name of the kubeconfig user to use
      --kubeconfig <KUBECONFIG>       The path to the kubeconfig file to use
      --as <IMPERSONATE_USER>         Username to impersonate for Kubernetes operations
      --as-group <IMPERSONATE_GROUP>  Group to impersonate for Kubernetes operations
      --admin-addr <ADMIN_ADDR>       The admin server's address [default: 0.0.0.0:8080]
  -h, --help                          Print help
  -V, --version                       Print version
```

When run it will write the manifest to `manifests/crd.yml`.

I also checked in the current one and added a job to the github actions workflow to verify that no changes to the CRD were introduced in a PR without committing them. I wasn't able to test this.