### PR TITLE
fix: use sinker ns

### DIFF
--- a/src/controller.rs
+++ b/src/controller.rs
@@ -37,9 +37,9 @@ async fn reconcile(sinker: Arc<ResourceSync>, ctx: Arc<Context>) -> Result<Actio
 
     let namespace = cluster_ref
         .and_then(|cluster_ref| cluster_ref.namespace.as_deref())
-        .or(sinker_ns.as_deref())
         .ok_or(Error::NamespaceRequired)?;
-    let secrets: Api<Secret> = Api::namespaced(client.clone(), namespace);
+
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), sinker_ns.as_deref().unwrap());
 
     let sec = secrets.get(&secret_ref.name).await?;
 


### PR DESCRIPTION
the sinker namespace shouldn't be used as an alternative to the cluster ref namespace, and the sinker namespace should be used instead of the cluster ref namespace when fetching the kubectl secret.